### PR TITLE
lesson: 스프링클라우드 1-5 클라이언트(order) 로드밸런싱 설정

### DIFF
--- a/src/main/java/com/spring_cloud/eureka/client/order/OrderApplication.java
+++ b/src/main/java/com/spring_cloud/eureka/client/order/OrderApplication.java
@@ -2,8 +2,10 @@ package com.spring_cloud.eureka.client.order;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 
 @SpringBootApplication
+@EnableFeignClients
 public class OrderApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/spring_cloud/eureka/client/order/OrderController.java
+++ b/src/main/java/com/spring_cloud/eureka/client/order/OrderController.java
@@ -1,0 +1,18 @@
+package com.spring_cloud.eureka.client.order;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class OrderController {
+
+    private final OrderService orderService;
+
+    @GetMapping("/order/{orderId}")
+    public String order(@PathVariable("orderId") String orderId){
+        return orderService.getOrder(orderId);
+    }
+}

--- a/src/main/java/com/spring_cloud/eureka/client/order/OrderService.java
+++ b/src/main/java/com/spring_cloud/eureka/client/order/OrderService.java
@@ -1,0 +1,24 @@
+package com.spring_cloud.eureka.client.order;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class OrderService {
+
+    private final ProductClient productClient;
+
+    public String getProductInfo(String productId) {
+        return productClient.getProduct(productId);
+    }
+
+    public String getOrder(String orderId) {
+        if(orderId.equals("1")){
+            String productId = "2";
+            String productInfo = getProductInfo(productId);
+            return "Your order is " + orderId +  " and " + productInfo;
+        }
+        return "Not exist order...";
+    }
+}

--- a/src/main/java/com/spring_cloud/eureka/client/order/ProductClient.java
+++ b/src/main/java/com/spring_cloud/eureka/client/order/ProductClient.java
@@ -1,0 +1,12 @@
+package com.spring_cloud.eureka.client.order;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@FeignClient(name = "product-service")
+public interface ProductClient {
+
+    @GetMapping("/product/{id}")
+    String getProduct(@PathVariable("id") String id);
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=order

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,9 @@
+spring:
+  application:
+    name: order-service
+server:
+  port: 19091
+eureka:
+  client:
+    service-url:
+      defaultZone: http://localhost:19090/eureka/


### PR DESCRIPTION
- close #1 
- 테스트 완료
<img width="1706" height="632" alt="스크린샷 2025-09-25 오후 1 13 34" src="https://github.com/user-attachments/assets/35cd7d94-6c06-4bda-bf64-dda1920ed6dd" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 주문 조회 API(GET /order/{orderId}) 추가 및 기본 응답 로직 제공.
  - 상품 서비스 연동(Feign 클라이언트) 활성화로 주문 처리 시 상품 정보 조회 지원.

- 설정
  - 애플리케이션 설정을 YAML로 구성: 서비스명(order-service), 서버 포트(19091), Eureka 서버 연동(http://localhost:19090/eureka/).
  - 기존 properties의 중복 애플리케이션 이름 설정 제거.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->